### PR TITLE
Feature/menu cache invalidation

### DIFF
--- a/Handlers/MenuWidgetOutputCachePartHandler.cs
+++ b/Handlers/MenuWidgetOutputCachePartHandler.cs
@@ -1,0 +1,50 @@
+﻿using IDeliverable.Widgets.Models;
+using Orchard.Caching;
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.Handlers;
+using Orchard.Core.Navigation.Models;
+using Orchard.Core.Navigation.Services;
+using Orchard.Environment.Extensions;
+
+namespace IDeliverable.Widgets.Handlers
+{
+    [OrchardFeature("IDeliverable.Widgets.OutputCache")]
+    public class MenuWidgetOutputCachePartHandler : ContentHandler
+    {
+        private readonly ISignals _signals;
+        private readonly IContentManager _contentManager;
+        private readonly IMenuService _menuService;
+
+        public MenuWidgetOutputCachePartHandler(ISignals signals, IContentManager contentManager, IMenuService menuService)
+        {
+            _signals = signals;
+            _contentManager = contentManager;
+            _menuService = menuService;
+
+            OnCreated<MenuPart>(EvictMenuWidgetCaches);
+            OnUpdated<MenuPart>(EvictMenuWidgetCaches);
+            OnRemoving<MenuPart>(EvictMenuWidgetCaches);
+        }
+
+        private void EvictMenuWidgetCaches(ContentContextBase context, MenuPart part)
+        {
+            if (context.Id == 0)
+            {
+                return;
+            }
+
+            // Get all the menu widgets who's menu contains this Menu Item, but only if the Output Cache Part has been bound to that Content Type
+            var menuWidgetOutputCacheParts = _contentManager.Query<OutputCachePart>().ForType("MenuWidget").List();
+
+            foreach (var outputCachePart in menuWidgetOutputCacheParts)
+            {
+                var menuWidgetPart = outputCachePart.ContentItem.As<MenuWidgetPart>();
+
+                if (menuWidgetPart != null && menuWidgetPart.MenuContentItemId == part.Menu.Id)
+                {
+                    _signals.Trigger(OutputCachePart.ContentSignalName(part.Menu.Id));
+                }
+            }
+        }
+    }
+}

--- a/Handlers/MenuWidgetOutputCachePartHandler.cs
+++ b/Handlers/MenuWidgetOutputCachePartHandler.cs
@@ -3,7 +3,6 @@ using Orchard.Caching;
 using Orchard.ContentManagement;
 using Orchard.ContentManagement.Handlers;
 using Orchard.Core.Navigation.Models;
-using Orchard.Core.Navigation.Services;
 using Orchard.Environment.Extensions;
 
 namespace IDeliverable.Widgets.Handlers
@@ -13,13 +12,11 @@ namespace IDeliverable.Widgets.Handlers
     {
         private readonly ISignals _signals;
         private readonly IContentManager _contentManager;
-        private readonly IMenuService _menuService;
 
-        public MenuWidgetOutputCachePartHandler(ISignals signals, IContentManager contentManager, IMenuService menuService)
+        public MenuWidgetOutputCachePartHandler(ISignals signals, IContentManager contentManager)
         {
             _signals = signals;
             _contentManager = contentManager;
-            _menuService = menuService;
 
             OnCreated<MenuPart>(EvictMenuWidgetCaches);
             OnUpdated<MenuPart>(EvictMenuWidgetCaches);
@@ -42,7 +39,7 @@ namespace IDeliverable.Widgets.Handlers
 
                 if (menuWidgetPart != null && menuWidgetPart.MenuContentItemId == part.Menu.Id)
                 {
-                    _signals.Trigger(OutputCachePart.ContentSignalName(part.Menu.Id));
+                    _signals.Trigger(OutputCachePart.ContentSignalName(menuWidgetPart.Id));
                 }
             }
         }

--- a/IDeliverable.Widgets.csproj
+++ b/IDeliverable.Widgets.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Drivers\WidgetExPartDriver.cs" />
     <Compile Include="Drivers\WidgetsContainerPartDriver.cs" />
     <Compile Include="Filters\WidgetOutputCacheFilter.cs" />
+    <Compile Include="Handlers\MenuWidgetOutputCachePartHandler.cs" />
     <Compile Include="Handlers\OutputCachePartHandler.cs" />
     <Compile Include="Handlers\WidgetExPartHandler.cs" />
     <Compile Include="Migrations\OutputCacheMigrations.cs" />


### PR DESCRIPTION
Adds cache invalidation for Menu Widgets whenever their associated menu is altered.

Currently covers menu item create, update, and remove.

https://github.com/OrchardCMS/Orchard/pull/6006 will enable cache invalidation for menu item re-ordering.