### PR TITLE
Adds basic support for OPC widget resource inclusion

### DIFF
--- a/Events/IResourceManagerEvents.cs
+++ b/Events/IResourceManagerEvents.cs
@@ -1,0 +1,12 @@
+﻿using Orchard.Events;
+
+namespace IDeliverable.Widgets.Events
+{
+    public interface IResourceManagerEvents : IEventHandler
+    {
+        void FootScriptRegistered(string script);
+        void HeadScriptRegistered(string script);
+        void ResourceRequired(string resourceType, string resourceName);
+        void ResourceIncluded(string resourceType, string resourcePath, string resourceDebugPath, string relativeFromPath);
+    }
+}

--- a/IDeliverable.Widgets.csproj
+++ b/IDeliverable.Widgets.csproj
@@ -48,6 +48,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\lib\autofac\Autofac.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -92,12 +96,14 @@
     <Content Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Services\EventRaisingResourceManager.cs" />
     <Compile Include="Controllers\WidgetAdminController.cs" />
     <Compile Include="Controllers\AjaxController.cs" />
     <Compile Include="Drivers\OutputCachePartDriver.cs" />
     <Compile Include="Drivers\AjaxifyPartDriver.cs" />
     <Compile Include="Drivers\WidgetExPartDriver.cs" />
     <Compile Include="Drivers\WidgetsContainerPartDriver.cs" />
+    <Compile Include="Events\IResourceManagerEvents.cs" />
     <Compile Include="Filters\WidgetOutputCacheFilter.cs" />
     <Compile Include="Handlers\MenuWidgetOutputCachePartHandler.cs" />
     <Compile Include="Handlers\OutputCachePartHandler.cs" />
@@ -105,13 +111,18 @@
     <Compile Include="Migrations\OutputCacheMigrations.cs" />
     <Compile Include="Migrations\AjaxWidgetMigrations.cs" />
     <Compile Include="Migrations\WidgetsContainerMigrations.cs" />
+    <Compile Include="Models\ResourceIncludedModel.cs" />
+    <Compile Include="Models\OutputCachedWidgetModel.cs" />
     <Compile Include="Models\OutputCachePart.cs" />
     <Compile Include="Models\AjaxifyPart.cs" />
+    <Compile Include="Models\ResourceRequiredModel.cs" />
     <Compile Include="Models\WidgetExPart.cs" />
     <Compile Include="Models\WidgetsContainerPart.cs" />
     <Compile Include="ResourceManifests\AjaxWidgetResourceManifest.cs" />
     <Compile Include="Routes\Routes.cs" />
     <Compile Include="Routes\AjaxWidgetRoutes.cs" />
+    <Compile Include="Services\DefaultOuputCachedWidgetsService.cs" />
+    <Compile Include="Services\IOuputCachedWidgetsService.cs" />
     <Compile Include="Services\IWidgetManager.cs" />
     <Compile Include="Services\WidgetManager.cs" />
     <Compile Include="Shapes\WidgetOutputCacheShapes.cs" />

--- a/Models/OutputCachedWidgetModel.cs
+++ b/Models/OutputCachedWidgetModel.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace IDeliverable.Widgets.Models
+{
+    public class OutputCachedWidgetModel
+    {
+        public OutputCachedWidgetModel()
+        {
+            RequiredResources = new List<ResourceRequiredModel>();
+            IncludedResources = new List<ResourceIncludedModel>();
+            FootScripts = new List<string>();
+            HeadScripts = new List<string>();
+        }
+
+        public string Html { get; set; }
+        public IEnumerable<ResourceRequiredModel> RequiredResources { get; set; }
+        public IEnumerable<ResourceIncludedModel> IncludedResources { get; set; }
+        public IList<string> FootScripts { get; set; }
+        public IList<string> HeadScripts { get; set; }
+    }
+}

--- a/Models/ResourceIncludedModel.cs
+++ b/Models/ResourceIncludedModel.cs
@@ -1,0 +1,10 @@
+﻿namespace IDeliverable.Widgets.Models
+{
+    public class ResourceIncludedModel
+    {
+        public string ResourceType { get; set; }
+        public string ResourcePath { get; set; }
+        public string ResourceDebugPath { get; set; }
+        public string RelativeFromPath { get; set; }
+    }
+}

--- a/Models/ResourceRequiredModel.cs
+++ b/Models/ResourceRequiredModel.cs
@@ -1,0 +1,8 @@
+﻿namespace IDeliverable.Widgets.Models
+{
+    public class ResourceRequiredModel
+    {
+        public string ResourceType { get; set; }
+        public string ResourceName { get; set; }
+    }
+}

--- a/Services/DefaultOuputCachedWidgetsService.cs
+++ b/Services/DefaultOuputCachedWidgetsService.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using IDeliverable.Widgets.Events;
+using IDeliverable.Widgets.Models;
+using Orchard.Environment.Extensions;
+
+namespace IDeliverable.Widgets.Services
+{
+    [OrchardFeature("IDeliverable.Widgets.OutputCache")]
+    public class DefaultOuputCachedWidgetsService : IOuputCachedWidgetsService, IResourceManagerEvents
+    {
+        private bool WithinContext { get; set; }
+        private IList<ResourceRequiredModel> RequiredResources { get; set; }
+        private IList<ResourceIncludedModel> IncludedResources { get; set; }
+        private IList<string> FootScripts { get; set; }
+        private IList<string> HeadScripts { get; set; }
+
+        public OutputCachedWidgetModel CaptureWidgetOutput(Func<string> htmlFactory)
+        {
+            var model = new OutputCachedWidgetModel();
+
+            try
+            {
+                WithinContext = true;
+                RequiredResources = new List<ResourceRequiredModel>();
+                IncludedResources = new List<ResourceIncludedModel>();
+                FootScripts = new List<string>();
+                HeadScripts = new List<string>();
+
+                model.Html = htmlFactory();
+
+                model.IncludedResources = IncludedResources;
+                model.RequiredResources = RequiredResources;
+                model.FootScripts = FootScripts;
+                model.HeadScripts = HeadScripts;
+            }
+            finally
+            {
+                WithinContext = false;
+            }
+
+
+            return model;
+        }
+
+        // When these events are raised while creating html to be cached, then we need to add a record of the values passed into the cache as well so that we can re-instate the resources when we get the html back from the cache
+        public void FootScriptRegistered(string script)
+        {
+            if (WithinContext)
+            {
+                FootScripts.Add(script);
+            }
+        }
+
+        public void HeadScriptRegistered(string script)
+        {
+            if (WithinContext)
+            {
+                HeadScripts.Add(script);
+            }
+        }
+
+        public void ResourceRequired(string resourceType, string resourceName)
+        {
+            if (WithinContext)
+            {
+                RequiredResources.Add(new ResourceRequiredModel
+                {
+                    ResourceType = resourceType,
+                    ResourceName = resourceName,
+                });
+            }
+        }
+
+        public void ResourceIncluded(string resourceType, string resourcePath, string resourceDebugPath, string relativeFromPath)
+        {
+            if (WithinContext)
+            {
+                IncludedResources.Add(new ResourceIncludedModel
+                {
+                    ResourceType = resourceType,
+                    ResourcePath = resourcePath,
+                    ResourceDebugPath = resourceDebugPath,
+                    RelativeFromPath = relativeFromPath
+                });
+            }
+        }
+    }
+}

--- a/Services/EventRaisingResourceManager.cs
+++ b/Services/EventRaisingResourceManager.cs
@@ -1,0 +1,57 @@
+﻿using IDeliverable.Widgets.Events;
+using Orchard.Environment.Extensions;
+using Orchard.UI.Resources;
+using System.Collections.Generic;
+using Autofac.Features.Metadata;
+
+namespace IDeliverable.Widgets.Services
+{
+    [OrchardFeature("IDeliverable.Widgets.OutputCache")]
+    [OrchardSuppressDependency("Orchard.UI.Resources.ResourceManager")]
+    public class EventRaisingResourceManager : ResourceManager
+    {
+        private readonly IResourceManagerEvents _resourceManagerEvents;
+
+        private bool SuppressRequireEvents { get; set; }
+
+        public EventRaisingResourceManager(IEnumerable<Meta<IResourceManifestProvider>> resourceProviders, IResourceManagerEvents resourceManagerEvents)
+            : base(resourceProviders)
+        {
+            _resourceManagerEvents = resourceManagerEvents;
+        }
+
+        public override void RegisterFootScript(string script)
+        {
+            base.RegisterFootScript(script);
+            _resourceManagerEvents.FootScriptRegistered(script);
+        }
+
+        public override void RegisterHeadScript(string script)
+        {
+            base.RegisterHeadScript(script);
+            _resourceManagerEvents.HeadScriptRegistered(script);
+        }
+
+        public override RequireSettings Require(string resourceType, string resourceName)
+        {
+            //include calls require under the hood, so we will end up with dupicate events in that case
+            if (!SuppressRequireEvents)
+            {
+                _resourceManagerEvents.ResourceRequired(resourceType, resourceName);
+            }
+
+            return base.Require(resourceType, resourceName);
+        }
+
+        public override RequireSettings Include(string resourceType, string resourcePath, string resourceDebugPath, string relativeFromPath)
+        {
+            SuppressRequireEvents = true;
+            var result = base.Include(resourceType, resourcePath, resourceDebugPath, relativeFromPath);
+            SuppressRequireEvents = false;
+
+            _resourceManagerEvents.ResourceIncluded(resourceType, resourcePath, resourceDebugPath, relativeFromPath);
+
+            return result;
+        }
+    }
+}

--- a/Services/IOuputCachedWidgetsService.cs
+++ b/Services/IOuputCachedWidgetsService.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using IDeliverable.Widgets.Models;
+using Orchard;
+
+namespace IDeliverable.Widgets.Services
+{
+    public interface IOuputCachedWidgetsService : IDependency
+    {
+        OutputCachedWidgetModel CaptureWidgetOutput(Func<string> htmlFactory);
+    }
+}


### PR DESCRIPTION
Widgets that are output cached now have the ability to use basic resource inclusion.

Supported functions are:

    Script.Include("script.js");
    Style.Include("style.css");

    Script.Require("script");
    Style.Require("style");

    using (Script.Head())
    {
    }

    using (Script.Foot())
    {
    }


Works by listening for calls to the resource manager during the `RenderWidget` call in the `CachedWidgetFilter`. These calls are then included in the cached model which are then in turn reinstated when rendering a widget from the cache.

Current limitations:

* Any additional data in the `RequireSettings` object will be lost (for example `.AtHead()` etc...)


The basis of this work could be used to resolve issue #2 as well.